### PR TITLE
Add ntfs to kernel modules

### DIFF
--- a/90ntfsloop/module-setup.sh
+++ b/90ntfsloop/module-setup.sh
@@ -21,5 +21,5 @@ install() {
 }
 
 installkernel() {
-    hostonly='' instmods fuse loop
+    hostonly='' instmods ntfs fuse loop
 }


### PR DESCRIPTION
For now kernel needs ntfs module for mounting NTFS partitions. Tested on CentOS 7.2